### PR TITLE
Typo Fit at Section 01 Logic Sheet 5: `rfl` instead of `refl` in Lean 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.lake/
+.DS_Store

--- a/FormalisingMathematics2024/Section01logic/Sheet1.lean
+++ b/FormalisingMathematics2024/Section01logic/Sheet1.lean
@@ -119,7 +119,10 @@ using `intro`, `exact` and `apply`.
 -/
 /-- Every proposition implies itself. -/
 example : P → P := by
-  sorry
+  -- intro assumption: `h` says `P`.
+  intro h
+  -- by reflexivity
+  exact h
   done
 
 /-
@@ -138,25 +141,44 @@ So the next level is asking you prove that `P → (Q → P)`.
 
 -/
 example : P → Q → P := by
-  sorry
+  -- intro assumption for `P`
+  intro hP
+  -- intro inner assumption for `Q`, but unused variable
+  intro _hQ
+  -- target: `P` is now satisfied
+  exact hP
   done
 
 /-- If we know `P`, and we also know `P → Q`, we can deduce `Q`.
 This is called "Modus Ponens" by logicians. -/
 example : P → (P → Q) → Q := by
-  sorry
+  intro h
+  intro hPQ
+  apply hPQ at h
+  exact h
   done
 
 /-- `→` is transitive. That is, if `P → Q` and `Q → R` are true, then
   so is `P → R`. -/
 example : (P → Q) → (Q → R) → P → R := by
-  sorry
+  intro h1
+  intro h2
+  intro h
+  apply h1 at h
+  apply h2 at h
+  exact h
   done
 
 -- If `h : P → Q → R` with goal `⊢ R` and you `apply h`, you'll get
 -- two goals! Note that tactics operate on only the first goal.
 example : (P → Q → R) → (P → Q) → P → R := by
-  sorry
+  intro h1
+  intro h2
+  intro h
+  apply h1
+  exact h
+  apply h2 at h
+  exact h
   done
 
 /-
@@ -171,27 +193,65 @@ in this section, where you'll learn some more tactics.
 variable (S T : Prop)
 
 example : (P → R) → (S → Q) → (R → T) → (Q → R) → S → T := by
-  sorry
+  intro _hPR
+  intro hSQ
+  intro hRT
+  intro hQR
+  intro hS
+  -- to prove: T
+  apply hRT
+  apply hSQ at hS
+  apply hQR at hS
+  exact hS
   done
 
 example : (P → Q) → ((P → Q) → P) → Q := by
-  sorry
+  intro hPQ
+  intro hInner
+  apply hPQ
+  apply hInner at hPQ
+  exact hPQ
   done
 
 example : ((P → Q) → R) → ((Q → R) → P) → ((R → P) → Q) → P := by
-  sorry
+  intro h1
+  intro h2
+  intro _h3
+  apply h2
+  intro hQ
+  apply h1
+  intro _hP
+  exact hQ
   done
 
 example : ((Q → P) → P) → (Q → R) → (R → P) → P := by
-  sorry
+  intro h1
+  intro h2
+  intro h3
+  apply h1
+  intro hQ
+  apply h2 at hQ
+  apply h3 at hQ
+  exact hQ
   done
 
 example : (((P → Q) → Q) → Q) → P → Q := by
-  sorry
+  intro h1
+  intro h2
+  apply h1
+  intro h3
+  apply h3 at h2
+  exact h2
   done
 
 example :
     (((P → Q → Q) → (P → Q) → Q) → R) →
       ((((P → P) → Q) → P → P → Q) → R) → (((P → P → Q) → (P → P) → Q) → R) → R := by
-  sorry
+  intro _h1 h2 _h3
+  apply h2
+  intro h4 _h5
+  intro _h6
+  apply h4
+  intro h7
+  apply h7
   done

--- a/FormalisingMathematics2024/Section01logic/Sheet2.lean
+++ b/FormalisingMathematics2024/Section01logic/Sheet2.lean
@@ -28,41 +28,56 @@ if you can understand what's going on.
 variable (P Q R : Prop)
 
 example : True := by
-  sorry
+  triv
   done
 
 example : True → True := by
-  sorry
+  intro _h
+  triv
   done
 
 example : False → True := by
-  sorry
+  intro _h
+  triv
   done
 
 example : False → False := by
-  sorry
+  exfalso
   done
 
 example : (True → False) → False := by
-  sorry
+  intro h
+  apply h
+  triv
   done
 
 example : False → P := by
-  sorry
+  exfalso
   done
 
 example : True → False → True → False → True → False := by
-  sorry
+  intro _h
+  exfalso
   done
 
 example : P → (P → False) → False := by
-  sorry
+  intro h
+  intro h1
+  apply h1 at h
+  exact h
   done
 
 example : (P → False) → P → Q := by
-  sorry
+  intro h0
+  intro h1
+  apply h0 at h1
+  exfalso
+  exact h1
   done
 
 example : (True → False) → P := by
-  sorry
+  intro h
+  exfalso
+  apply h
+  triv
   done

--- a/FormalisingMathematics2024/Section01logic/Sheet3.lean
+++ b/FormalisingMathematics2024/Section01logic/Sheet3.lean
@@ -33,45 +33,91 @@ and the following tactics may also be useful:
 variable (P Q R : Prop)
 
 example : ¬True → False := by
-  sorry
+  intro h
+  change True → False at h
+  apply h
+  triv
   done
 
 example : False → ¬True := by
-  sorry
+  intro h
+  change True -> False
+  exfalso
+  exact h
   done
 
 example : ¬False → True := by
-  sorry
+  intro _h
+  triv
   done
 
 example : True → ¬False := by
-  sorry
+  intro _h
+  change False → False
+  exfalso
   done
 
 example : False → ¬P := by
-  sorry
+  exfalso
   done
 
 example : P → ¬P → False := by
-  sorry
+  intro hP -- assume P
+  intro hnP
+  apply hnP
+  exact hP
   done
 
 example : P → ¬¬P := by
-  sorry
+  intro hP
+  change ¬P→False
+  intro hnP
+  change P→False at hnP
+  apply hnP at hP
+  exact hP
+  done
+
+-- another implementation using `by_contra`
+example : P → ¬¬P := by
+  intro hP
+  by_contra hnP
+  change P→False at hnP
+  apply hnP at hP
+  exact hP
   done
 
 example : (P → Q) → ¬Q → ¬P := by
-  sorry
+  intro hPQ
+  intro hnQ
+  by_contra hP
+  change Q→False at hnQ
+  apply hPQ at hP
+  apply hnQ at hP
+  exact hP
   done
 
 example : ¬¬False → False := by
-  sorry
+  intro h
+  by_contra h1
+  change ¬False→False at h
+  apply h at h1
+  exact h1
   done
 
 example : ¬¬P → P := by
-  sorry
+  intro h
+  by_contra h1
+  change ¬P→False at h
+  apply h at h1
+  exact h1
   done
 
 example : (¬Q → ¬P) → P → Q := by
-  sorry
+  intro h
+  intro h1
+  by_contra h2
+  apply h at h2
+  change P→False at h2
+  apply h2 at h1
+  exact h1
   done

--- a/FormalisingMathematics2024/Section01logic/Sheet4.lean
+++ b/FormalisingMathematics2024/Section01logic/Sheet4.lean
@@ -26,39 +26,71 @@ and also the following tactics:
 variable (P Q R : Prop)
 
 example : P ∧ Q → P := by
-  sorry
+  intro h
+  cases' h with hP hQ
+  exact hP
   done
 
 example : P ∧ Q → Q := by
-  sorry
+  intro h
+  rcases h with ⟨_h1, h2⟩
+  exact h2
   done
 
 example : (P → Q → R) → P ∧ Q → R := by
-  sorry
+  intro h1
+  intro h2
+  cases' h2 with hP hQ
+  apply h1 at hP
+  apply hP at hQ
+  exact hQ
   done
 
 example : P → Q → P ∧ Q := by
-  sorry
+  intro h1
+  intro h2
+  constructor
+  {exact h1}
+  {exact h2}
   done
 
 /-- `∧` is symmetric -/
 example : P ∧ Q → Q ∧ P := by
-  sorry
+  intro h
+  cases' h with hP hQ
+  constructor
+  {exact hQ}
+  {exact hP}
   done
 
 example : P → P ∧ True := by
-  sorry
+  intro h
+  constructor
+  {exact h}
+  {triv}
   done
 
 example : False → P ∧ False := by
-  sorry
+  exfalso
   done
 
 /-- `∧` is transitive -/
 example : P ∧ Q → Q ∧ R → P ∧ R := by
-  sorry
+  intro h1
+  intro h2
+  cases' h1 with hP _hQ
+  cases' h2 with _hQ hR
+  constructor
+  {exact hP}
+  {exact hR}
   done
 
 example : (P ∧ Q → R) → P → Q → R := by
-  sorry
+  intro h1
+  intro h2
+  intro h3
+  apply h1
+  constructor
+  {exact h2}
+  {exact h3}
   done

--- a/FormalisingMathematics2024/Section01logic/Sheet5.lean
+++ b/FormalisingMathematics2024/Section01logic/Sheet5.lean
@@ -16,7 +16,7 @@ We learn about how to manipulate `P ↔ Q` in Lean.
 You'll need to know about the tactics from the previous sheets,
 and also the following two new tactics:
 
-* `refl`
+* `rfl`
 * `rw`
 
 -/


### PR DESCRIPTION
As title said. `refl` gives an error whilst `rfl` is the command to use