### PR TITLE
fix: typo at section 1 sheet 5: `refl` not used but `rfl`

### DIFF
--- a/FormalisingMathematics2024/Section01logic/Sheet5.lean
+++ b/FormalisingMathematics2024/Section01logic/Sheet5.lean
@@ -16,7 +16,7 @@ We learn about how to manipulate `P ↔ Q` in Lean.
 You'll need to know about the tactics from the previous sheets,
 and also the following two new tactics:
 
-* `refl`
+* `rfl`
 * `rw`
 
 -/


### PR DESCRIPTION
`refl` does not work out as the reflexive tactic implied here for theorem proving purposes and would be reported as error.
It seems that `refl` and `rfl` do differ in usage according to [Theorem Proving in Lean 4](https://leanprover.github.io/theorem_proving_in_lean4/tactics.html)